### PR TITLE
Remove redundant word from alt attribute

### DIFF
--- a/src/components/Champion.jsx
+++ b/src/components/Champion.jsx
@@ -67,7 +67,7 @@ export const Champion = () => {
     <ChampionRoot>
       <Confetti />
       <Picture>
-        <img src={unicorn} alt="Photo of a stuffed unicorn" />
+        <img src={unicorn} alt="A stuffed unicorn" />
       </Picture>
       <RibbonWrapper>
         <Ribbon />


### PR DESCRIPTION
Fixes the following warning:

> 70:9  warning  Redundant alt attribute. Screen-readers already
> announce `img` tags as an image. You don’t need to use the words
> `image`, `photo,` or `picture` (or any specified custom words) in the
> alt prop jsx-a11y/img-redundant-alt